### PR TITLE
Added EthernetLink class with examples

### DIFF
--- a/EthernetLink.cpp
+++ b/EthernetLink.cpp
@@ -1,0 +1,226 @@
+#include <Arduino.h>
+#include <PJON.h>
+#include <EthernetLink.h>
+
+// TODO:
+// 1. Checksum
+// 2. Retransmission if not ACKED
+// 3. Support ENC28J60 based Ethernet shields
+
+// Magic number to verify that we are aligned with telegram start and end
+#define HEADER 0x18ABC427
+#define FOOTER 0x9ABE8873
+#define SUCCESS 0x101
+
+#define DEBUGPRINT
+
+void EthernetLink::init() { 
+  _server = NULL;
+  _currentDevice = -1;
+  _keep_connection = false;
+  _local_id = 0;
+  memset(_local_ip, 0, 4);
+  _local_port = DEFAULT_PORT;
+  _receiver = NULL;
+  _error = NULL; 
+  for (int i=0; i<MAX_REMOTE_NODES; i++) {
+	_remote_id[i] = 0;
+    memset(_remote_ip[i], 0, 4);
+    _remote_port[i] = 0;
+  }
+}
+
+int EthernetLink::read_bytes(EthernetClient &client, byte *contents, int length) {
+//	return client.read(contents, length);
+  int bytes_read = 0;	
+  unsigned long start_ms = millis(); 
+  for (int i=0; i<length && client.connected() && start_ms + 10000 > millis(); i++) {
+	while (client.available() == 0 && client.connected() && start_ms + 10000 > millis()) ; // Wait for next byte 	 
+    contents[i] = client.read();
+	bytes_read++;
+  }
+  return bytes_read;
+}
+  
+int EthernetLink::receive() {
+  if (_server == NULL) start_listening(_local_port);  
+/*  
+#ifdef DEBUGPRINT
+  static unsigned long first = millis();
+  if (first + 5000 < millis()) {
+    first = millis();  
+    Serial.println("Waiting for client to connect..."); 
+  }
+#endif
+*/	  
+  EthernetClient client = _server->available();
+  if (client) {
+#ifdef DEBUGPRINT
+  Serial.println("A client connected!"); 
+#endif	  
+    // Read encapsulation header (4 bytes magic number)
+    bool ok = true;	
+	long head = 0;
+	int bytes_read = read_bytes(client, (byte*) &head, 4);
+	if (bytes_read != 4 || head != HEADER) ok = false;
+#ifdef DEBUGPRINT
+  Serial.print("Read header, status: "); Serial.println(ok); 
+#endif
+	
+	// Read sender device id
+	uint8_t sender_id = 0;
+	if (ok) {
+      bytes_read = read_bytes(client, (byte*) &sender_id, 1);
+      if (bytes_read != 1) ok = false;
+    }
+	
+	// Read length of contents (4 bytes)
+	long content_length = 0;
+	if (ok) {
+      bytes_read = read_bytes(client, (byte*) &content_length, 4);
+      if (bytes_read != 4 || content_length <= 0) ok = false;
+    }
+	
+	// Read contents
+	byte buf[content_length];
+	if (ok) {
+      bytes_read = read_bytes(client, (byte*) &buf, content_length);
+      if (bytes_read != content_length) ok = false;
+    }
+	  
+	// Read footer (4 bytes magic number)
+	long foot = 0;
+	if (ok) {		
+      bytes_read = read_bytes(client, (byte*) &foot, 4);
+      if (bytes_read != 4 || foot != FOOTER) ok = false;
+    }
+#ifdef DEBUGPRINT
+  Serial.print("Status before sending ACK: "); Serial.println(ok); 
+#endif
+
+	// Write ACK
+	long returncode = ok ? ACK : NAK;
+	int acklen = 0;
+	if (client.connected()) acklen = client.write((byte*) &returncode, 4);
+    client.flush();
+
+#ifdef DEBUGPRINT
+  Serial.print("Sent "); Serial.print(ok ? "ACK: " : "NAK: "); Serial.println(acklen); 
+#endif
+	
+	// Call receiver callback function
+	if (ok) _receiver(sender_id, buf, content_length);
+	
+	// Close connection
+	if (!_keep_connection || !client.connected()) client.stop();
+	
+    return ok;	
+  }
+  return false;
+}
+
+// TODO: Call error callback at appropriate times with appropriate codes
+
+
+int EthernetLink::receive(unsigned long duration_us) {
+  unsigned long start = micros();
+  int result = FAIL;
+  do {
+    result = receive();
+  } while (result != ACK && !(start + duration_us < micros()));
+  return result;
+}
+
+int EthernetLink::send(uint8_t id, char *packet, uint8_t length, unsigned long timing_us) {
+  // Locate the node's IP address and port number
+  int pos = find_remote_node(id);
+#ifdef DEBUGPRINT
+  Serial.print("Send to server pos="); Serial.println(pos); 
+#endif
+  if (pos < 0) return FAIL;
+  
+  // Try to deliver the package
+  EthernetClient _client;
+  if (!_client.connected()) _client.stop();
+  if (!_keep_connection  || (_currentDevice != id && _client.connected())) {
+#ifdef DEBUGPRINT
+    if (_keep_connection && _currentDevice != -1) Serial.println("Switching connection to another server.");
+#endif
+    while (_client.connected()) _client.stop();
+  }
+  unsigned long start = micros();
+  int result = FAIL;
+#ifdef DEBUGPRINT
+  if (!_client.connected()) Serial.println("Trying to connect...");
+#endif  
+  do {
+    if ((_keep_connection && _client && _client.connected()) 
+		|| _client.connect(_remote_ip[pos], _remote_port[pos])) {
+#ifdef DEBUGPRINT
+      Serial.println("Connected to server!");
+#endif
+      _currentDevice = id;
+      int bytes_sent = 0, bytes_total = 0;
+	  long head = HEADER, foot = FOOTER, len = length;
+	  bytes_sent = _client.write((byte*) &head, 4);
+	  bytes_sent = _client.write((byte*) &id, 1);
+	  bytes_sent = _client.write((byte*) &len, 4);
+	  do {	
+        bytes_sent = _client.write(&packet[bytes_total], length-bytes_total);		
+	    bytes_total += bytes_sent;
+	  } while (bytes_sent > 0 && bytes_total < length);
+	  if (bytes_total == length) result = SUCCESS;
+	  bytes_sent = _client.write((byte*) &foot, 4);
+	  _client.flush();	
+    }
+  } while (result != SUCCESS && (timing_us == 0 || !(start + timing_us < micros())));
+#ifdef DEBUGPRINT
+  Serial.print("Write status: "); Serial.println(result == SUCCESS); 
+#endif
+    
+  // Read ACK
+  if (result == SUCCESS) {
+	result = FAIL;  
+	long code = 0; 
+    //unsigned long start_us = micros();	
+    int bytes_read = read_bytes(_client, (byte*) &code, 4);
+    if (bytes_read == 4 && (code == ACK || code == NAK)) result = code;	  
+  }
+#ifdef DEBUGPRINT
+  Serial.print("ACK status: "); Serial.println(result == ACK); 
+#endif
+  
+  // Disconnect
+  if (!_keep_connection) _client.stop();
+  
+  return result;  // FAIL, ACK or NAK
+}
+
+int EthernetLink::find_remote_node(uint8_t id) {
+  for (int i=0; i<MAX_REMOTE_NODES; i++) if (_remote_id[i] == id) return i;
+  return -1;
+}
+
+int EthernetLink::add_node(uint8_t remote_id, const uint8_t remote_ip[], uint16_t port_number) {
+  // Find free slot
+  int pos = find_remote_node(0);
+  if (pos < 0) return pos; // All slots taken
+
+  _remote_id[pos] = remote_id;
+  memcpy(_remote_ip[pos], remote_ip, 4);
+  _remote_port[pos] = port_number;
+  return pos;
+}
+
+void EthernetLink::start_listening(uint16_t port_number) {
+  if (_server != NULL) return; // Already started	
+#ifdef DEBUGPRINT
+  Serial.print("Started listening for connections on port "); Serial.println(port_number); 
+#endif	  
+  _server = new EthernetServer(port_number);	
+  _server->begin();
+}
+
+void EthernetLink::stop_listening() {
+  if (_server) delete _server; _server = NULL;  
+}

--- a/EthernetLink.h
+++ b/EthernetLink.h
@@ -1,0 +1,63 @@
+#ifndef _ETHERNET_LINK_
+#define _ETHERNET_LINK_
+
+#include <Link.h>
+#include <Ethernet.h>
+#include <EthernetClient.h>
+#include <EthernetServer.h>
+
+#define MAX_REMOTE_NODES 10
+#define DEFAULT_PORT     9000
+
+class EthernetLink : public Link {
+private:
+	receiver  _receiver;
+	error 	  _error;
+	
+	// Local node
+	uint8_t        _local_id;
+	uint8_t        _local_ip[4];
+	unsigned short _local_port;
+	
+	// Remote nodes
+	uint8_t        _remote_id[MAX_REMOTE_NODES];
+	uint8_t        _remote_ip[MAX_REMOTE_NODES][4];
+	unsigned short _remote_port[MAX_REMOTE_NODES];
+	
+	EthernetServer *_server;
+	EthernetClient _client;
+	short _currentDevice;
+	bool _keep_connection;
+	
+	void init();
+	int find_remote_node(uint8_t id);
+	int read_bytes(EthernetClient &client, byte *contents, int length);
+public:
+	EthernetLink() { init(); }
+	EthernetLink(uint8_t id) { init(); set_id(id); }
+
+	int add_node(uint8_t remote_id, const uint8_t remote_ip[], uint16_t port_number = DEFAULT_PORT);
+	void start_listening(uint16_t port_number = DEFAULT_PORT);
+	void stop_listening();	
+
+	// Whether to keep outgoing connection live until we need connect to another EthernetLink node
+	void keep_connection(bool keep) { _keep_connection = keep; }
+	
+	//**************** Overridden functions below *******************
+	
+    int receive();
+    int receive(unsigned long duration_us);
+
+	int send(uint8_t id, char *packet, uint8_t length, unsigned long timing_us = 0);
+
+    void    set_id(uint8_t id) { _local_id = id; }
+    void    set_error(error e) { _error = e; }
+    void    set_receiver(receiver r) { _receiver = r; }
+
+    uint8_t device_id() { return _local_id; }
+    uint8_t acquire_id() { return 0; } // Not supported yet
+
+    void update() {}
+};
+
+#endif

--- a/Link.h
+++ b/Link.h
@@ -1,3 +1,5 @@
+#ifndef _LINK_H_
+#define _LINK_H_
 
 /*
 
@@ -10,24 +12,25 @@
 
  */
 
-typedef void (* receiver)(uint8_t length, uint8_t *payload);
+
+typedef void (* receiver)(uint8_t id, uint8_t *payload, uint8_t length);
 typedef void (* error)(uint8_t code, uint8_t data);
 
 class Link {
   public:
-    //virtual ~Link();
+    virtual int receive() = 0;
+    virtual int receive(unsigned long duration) = 0;
 
-    virtual int receive();
-    virtual int receive(unsigned long duration);
+    virtual int send(uint8_t id, char *packet, uint8_t length, unsigned long timing = 0) = 0;
 
-    virtual int send(uint8_t id, char *packet, uint8_t length, unsigned long timing = 0);
+    virtual void    set_id(uint8_t id) = 0;
+    virtual void    set_error(error e) = 0;
+    virtual void    set_receiver(receiver r) = 0;
 
-    virtual void    set_id(uint8_t id);
-    virtual void    set_error(error e);
-    virtual void    set_receiver(receiver r);
+    virtual uint8_t device_id() = 0;
+    virtual uint8_t acquire_id() = 0;
 
-    virtual uint8_t device_id();
-    virtual uint8_t acquire_id();
-
-    virtual void update();
+    virtual void update() = 0;
 };
+
+#endif

--- a/examples/EthernetLinkReceiver/EthernetLinkReceiver.ino
+++ b/examples/EthernetLinkReceiver/EthernetLinkReceiver.ino
@@ -1,0 +1,40 @@
+#include <Arduino.h>
+#include <EthernetLink.h>
+
+// Ethernet settings
+byte REMOTEIP1[] = {192,168,1,110 };
+byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };  
+byte ip[] = { 192, 168, 1, 111 };    
+byte gateway[] = { 192, 168, 1, 1 };
+byte subnet[] = { 255, 255, 255, 0 };
+
+// Device ID
+#define LOCALID 45
+#define REMOTEID1 44
+
+EthernetLink ethernetLink(LOCALID);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("Welcome to EthernetLinkReceiver");
+  pinMode(13, OUTPUT);
+  
+  Ethernet.begin(mac, ip, gateway, subnet);
+  ethernetLink.add_node(REMOTEID1, REMOTEIP1);
+  ethernetLink.set_receiver(receiver_function);
+  ethernetLink.set_error(error_function);
+  ethernetLink.start_listening();
+}
+
+void loop() {  
+  ethernetLink.update();
+  ethernetLink.receive(1000);
+}
+
+void receiver_function(uint8_t id, uint8_t *payload, uint8_t length) {
+  ethernetLink.send(REMOTEID1, "FINE, THANK YOU!", 17); // Including null-term, so safe to print
+  Serial.print("Received request: "); Serial.println((const char *) payload);}
+
+void error_function(uint8_t code, uint8_t data) {
+  Serial.print("Got error code "); Serial.println(code);
+}

--- a/examples/EthernetLinkSender/EthernetLinkSender.ino
+++ b/examples/EthernetLinkSender/EthernetLinkSender.ino
@@ -1,0 +1,48 @@
+#include <Arduino.h>
+#include <EthernetLink.h>
+
+// Ethernet settings
+byte REMOTEIP1[] = { 192,168,1,111 };
+byte mac[] = { 0xDF, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };  
+byte ip[] = { 192, 168, 1, 110 };    
+byte gateway[] = { 192, 168, 1, 1 };
+byte subnet[] = { 255, 255, 255, 0 };
+
+// Device ID
+#define LOCALID 44
+#define REMOTEID1 45
+
+EthernetLink ethernetLink(LOCALID);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("Welcome to EthernetLinkSender");
+  pinMode(13, OUTPUT);
+  
+  Ethernet.begin(mac, ip, gateway, subnet);
+  ethernetLink.add_node(REMOTEID1, REMOTEIP1);
+  ethernetLink.set_receiver(receiver_function);
+  ethernetLink.set_error(error_function);
+  ethernetLink.start_listening();
+}
+
+void loop() {
+  // Send a package every few seconds
+  static unsigned long last = millis();
+  unsigned long now = millis();
+  if (last + 5000 <= now) {
+    last = now;
+    ethernetLink.send(REMOTEID1, "HOW DO YOU DO?", 15); // Including null-term, so safe to print
+  }
+  
+  ethernetLink.update();
+  ethernetLink.receive(1000);
+}
+
+void receiver_function(uint8_t id, uint8_t *payload, uint8_t length) {
+  Serial.print("Received reply: "); Serial.println((const char *) payload);  
+}
+
+void error_function(uint8_t code, uint8_t data) {
+  Serial.print("Got error code: "); Serial.println(code);
+}

--- a/examples/PJONEthernetRouter/PJONEthernetRouter.ino
+++ b/examples/PJONEthernetRouter/PJONEthernetRouter.ino
@@ -1,0 +1,49 @@
+/*
+ * PJONEthernetRouter
+ * This sketch is meant for an arduino with an Ethernet shield, and also connected to one or more PJON media.
+ * It is meant to be run in multiple instances, with a routing table that will pick up all packages to destined for a bus
+ * that the routing table indocates that this instance can deliver to. The instance responsible for the target bus on the
+ * the other end of the Ethernet connection will deliver it to a PJON media on its side so.
+ * 
+ * Arduino A - <PJON wired or wireless> - PJONEthernetRouterA - <TCP/IP> - PJONEthernetRouterB - <PJON wired or wireless> - Arduino B
+ * 
+ * The Ethernet TCP/IP connections may cross network segments or go through the Internet as long as a route is open.
+ */
+
+#include <Arduino.h>
+#include <OSPREY.h>
+#include <EthernetLink.h>
+#include <PJONLink.h>
+
+// Ethernet settings
+byte REMOTEIP1[] = { 192,168,1,10 };
+byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };  
+byte ip[] = { 192, 168, 1, 11 };    
+byte gateway[] = { 192, 168, 1, 1 };
+byte subnet[] = { 255, 255, 255, 0 };
+
+// Device ID
+#define REMOTEID1 45
+#define LOCALID 44
+
+// PJON settings
+#define PJONPIN 7
+uint8_t LOCALBUS[] =  { 0xAA, 0xBB, 0xCC, 0xDD };
+uint8_t REMOTEBUS[] = { 0xBB, 0xCC, 0xDD, 0xEE };
+
+OSPREY osprey;
+PJONLink pjonLink<SoftwareBitBang>(LOCALID);
+EthernetLink ethernetLink(LOCALID);
+
+void setup() {
+  Ethernet.begin(mac, ip); //, gateway, subnet);
+  pjonLink.set_pin(PJONPIN);
+  ethernetLink.add_node(REMOTEID1, REMOTEIP1);
+  osprey.add_bus(ethernetLink, REMOTEBUS, true);
+  osprey.add_bus(pjonLink, LOCALBUS, true);
+}
+
+void loop() {
+  osprey.receive(1000);
+  osprey.update();  
+}

--- a/examples/PJONEthernetTunneler/PJONEthernetTunneler.ino
+++ b/examples/PJONEthernetTunneler/PJONEthernetTunneler.ino
@@ -1,0 +1,79 @@
+/*
+ * PJONEthernetTunneler
+ * This sketch is meant for an arduino with an Ethernet shield, and also connected to a PJON media.
+ * It is meant to be run in two instances, and will send incoming PJON messages through an ethernet tunnel to another instance 
+ * of this sketch which will again deliver it to a PJON media on its side.
+ * 
+ * Arduino A - <PJON wired or wireless> - PJONEthernetTunnelB - <TCP/IP> - PJONEthernetTunnelA - <PJON wired or wireless> - Arduino B
+ *  (ID 45)                                    (ID 44)                           (ID 45)                                     (ID 44)
+ * 
+ * So device A can send a message to device B, and the message will be delivered to device B on the remote media.
+ * And also in the reverse direction. The device acts as a stand-in Proxy, connecting two buses with a fixed recipient on each side.
+ * 
+ * The Ethernet TCP/IP connections may cross network segments or go through the Internet as long as a route is open.
+ */
+
+#include <Arduino.h>
+#include <PJON.h>
+#include <EthernetLink.h>
+
+// Basic Ethernet settings
+byte gateway[] = { 192, 168, 1, 1 };
+byte subnet[] = { 255, 255, 255, 0 };
+
+// Devices
+uint8_t this_device = 0; // 0 or 1, chooses which PJON/Ethernet device this is
+uint8_t ids[] = { 44, 45 };
+byte ip[][4] = { { 192, 168, 1, 10 }, { 192, 168, 1, 11 } };
+byte mac[][6] = { { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED }, { 0xDF, 0xAD, 0xBE, 0xEF, 0xFE, 0xED } };  
+
+// PJON settings
+#define PJONPIN 7
+
+PJON<SoftwareBitBang> pjon(ids[this_device]);
+EthernetLink ethernetLink(ids[this_device]);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.print("Welcome to PJONEthernetTunneler, role ");
+  Serial.println(this_device);
+  
+  Ethernet.begin(mac[this_device], ip[this_device], gateway, subnet);
+  delay(1000);
+  ethernetLink.set_receiver(ethernet_receiver);
+  ethernetLink.add_node(ids[1-this_device], ip[1-this_device]);
+  ethernetLink.start_listening();
+  
+  pjon.set_pin(PJONPIN);
+  pjon.set_receiver(pjon_receiver);
+}
+
+void loop() {
+  pjon.receive(1000);
+  pjon.update();
+
+  ethernetLink.receive(1000);
+  ethernetLink.update();
+}
+
+void ethernet_receiver(uint8_t id, uint8_t *payload, uint8_t length) {
+  Serial.print("Forwarded Ethernet message from E_ID "); Serial.print(id);
+  Serial.print(" to P_ID device "); Serial.print(ids[1-this_device]);
+  print_payload(payload, length);
+  pjon.send(ids[1-this_device], (char *)payload, length);
+}
+
+void pjon_receiver(uint8_t id, uint8_t *payload, uint8_t length) {
+  Serial.print("Forwarded PJON message from P_ID "); Serial.print(id);
+  Serial.print(" to E_ID device "); Serial.print(ids[1-this_device]);
+  print_payload(payload, length);
+  ethernetLink.send(ids[1-this_device], (char *)payload, length, 10000000);
+}
+
+void print_payload(uint8_t *payload, uint8_t length) {
+  char buf[length+1];
+  memcpy(buf, payload, length);
+  buf[length] = 0;
+  Serial.print(", data:'"); Serial.print(buf); Serial.println("'.");
+}
+


### PR DESCRIPTION
Changed Link to be abstract and added #ifdef for multiple inclusion.
Added class EthernetLink based on the Link class.
Added working examples EthernetLinSender, EthernetLinkReceiver and EthernetLinkTunneler.
The example EthernetLinkRouter is based on a working OSPREY, so not in action yet.